### PR TITLE
outdated: Remove unnecessary items from for loop

### DIFF
--- a/outdated/index.html
+++ b/outdated/index.html
@@ -83,7 +83,7 @@ section h4 ~ p {
     <script>
 window.addEventListener('load', function() {
   var els = document.querySelectorAll('[data-bind]')
-  for(var i in els) {
+  for (var i = 0; i < len.length; ++i) {
     var el = els[i]
     var exp = el.getAttribute('data-bind')
     var val = ''


### PR DESCRIPTION
A `NodeList` object returned by `document.querySelectorAll` has several methods. Therefore, those methods are also enumerated in a loop using for-in.

```javascript
var result = []
var ary = document.querySelectorAll(':root')
for (var key in ary) result.push(key)
console.log(result) // => ["0", "length", "item", "entries", "forEach", "keys", "values"]
```

For NodeList objects you should avoid using for-in.

### Screenshot on DevTools

![](https://user-images.githubusercontent.com/12539/32261566-c84f98ee-bf12-11e7-8598-55c06898ef52.png)