### PR TITLE
name blur improvements

### DIFF
--- a/overlay/css/table.css
+++ b/overlay/css/table.css
@@ -62,10 +62,13 @@
 .pet-merged .flex-column-i-owner {
   display: none !important;
 }
-.nameblur #table li:not(.me) .flex-column-i-name,
-.nameblur #table li:not(.me) .flex-column-i-owner {
+.nameblur #table li:not(.me):not(.class-limit-break) .flex-column-i-name,
+.nameblur #table li:not(.me):not(.class-limit-break) .flex-column-i-owner {
   filter: blur(0.2rem) -webkit-blur(0.2rem);
   -webkit-filter: blur(0.2rem);
+
+  margin-left: -0.3rem;
+  padding-left: 0.3rem;
 }
 .zero {
   opacity: 0.75;


### PR DESCRIPTION
### Current behavior

![1](https://user-images.githubusercontent.com/9481405/48665921-e042d500-eafa-11e8-8a7a-73eb36286282.PNG)

* wrongly styled left edge (too sharp)
* "Limit Break" is unnecessarily blurred

### Fixed behavior

![2](https://user-images.githubusercontent.com/9481405/48665922-e20c9880-eafa-11e8-8a3a-f1bcc7e1a744.PNG)

### Environment
| ACT | `3.3.1` |
| :-- | :-- |
| FFXIV_ACT_Plugin | `1.7.0.11` |
| OverlayPlugin | `0.3.4.0` |
| kagerou | `0.7.22` |


