### PR TITLE
fit resize handle position

### DIFF
--- a/overlay/css/index.css
+++ b/overlay/css/index.css
@@ -33,6 +33,10 @@ body::after {
   border-color: transparent rgba(127, 127, 127, 0.3) rgba(127, 127, 127, 0.3) transparent;
   background: rgba(127, 127, 127, 0.1);
 }
+body.overlay::after {
+  right: 0.25rem;
+  bottom: 0.25rem;
+}
 body.disable-handle::after {
   display: none;
 }


### PR DESCRIPTION
### Current behavior
![handle-before](https://user-images.githubusercontent.com/9481405/49153035-dec5a800-f357-11e8-9df8-da00740b684c.png)
> Resize handle is overflowed (see right bottom corner)

### Fixed behavior
![handle-after](https://user-images.githubusercontent.com/9481405/49153037-e08f6b80-f357-11e8-9899-c2c3fb841aa2.png)

### Environment
| ACT | `3.3.1` |
| :-- | :-- |
| FFXIV_ACT_Plugin | `1.7.0.11` |
| OverlayPlugin | `0.3.4.0` |
| kagerou | `0.7.23` |