### PR TITLE
Add missing BLU gauge color

### DIFF
--- a/overlay/css/table.css
+++ b/overlay/css/table.css
@@ -100,6 +100,7 @@
 .class-mch .gauge { background: var(--mch); }
 .class-sam .gauge { background: var(--sam); }
 .class-rdm .gauge { background: var(--rdm); }
+.class-blu .gauge { background: var(--blu); }
 .class-dnc .gauge { background: var(--dnc); }
 
 .class-cnj .gauge, .class-whm .gauge { background: var(--whm); }


### PR DESCRIPTION
Blue Mage has an entry in the configuration page, but it is currently unused, resulting in it using default color.

This PR adds BLU to the table stylesheet.

You can quickly test at `https://fabulouscupcake.github.io/kagerou/overlay/`