### PR TITLE
formatDps: Added decimal comma thousands separator

### DIFF
--- a/share/lib/util.js
+++ b/share/lib/util.js
@@ -167,7 +167,7 @@ const formatDps = function formatDPSNumberWithSmalls(number, decimals, abbr, typ
   number = (
     typeof number === 'string'? pFloat(number)
   : typeof number === 'number'? number
-  : 0).toFixed(decimals)
+  : 0).toLocaleString()
 
   if(number >= 1000 || abbrUnit) {
     type += ' with-larger-digits'


### PR DESCRIPTION
replaced .toFixed(decimals) with .toLocaleString() to give the damage and dps a thousands separator to make it easier to read and to look more tidy. 

not sure If this will mess up anything but It's working fine for me giving both damage and dps thousands separators while still keeping the dps decimals.

![new](https://user-images.githubusercontent.com/46814896/123678151-1099a500-d89a-11eb-8dd3-9414e149a912.PNG)
