### PR TITLE
Mix muffins deathsort

### DIFF
--- a/config/lib/tabconfig.js
+++ b/config/lib/tabconfig.js
@@ -14,6 +14,7 @@
     'damagetaken': 'tank.damage',
     'enchps': 'heal.per_second',
     'healed': 'heal.total',
+    'deaths': 'etc.death'
   }
 
   const forceFallback = navigator.userAgent.indexOf('QtWebEngine') !== -1

--- a/overlay/lib/render.js
+++ b/overlay/lib/render.js
@@ -19,7 +19,7 @@
     '+healed': 'heal.total',
     '-healed': 'heal.total',
     '-deaths': 'etc.death',
-    '+deaths': 'etc.death',
+    '+deaths': 'etc.death'
   }
 
   class Renderer {

--- a/overlay/lib/render.js
+++ b/overlay/lib/render.js
@@ -17,7 +17,9 @@
     '+enchps': 'heal.per_second',
     '-enchps': 'heal.per_second',
     '+healed': 'heal.total',
-    '-healed': 'heal.total'
+    '-healed': 'heal.total',
+    '-deaths': 'etc.death',
+    '+deaths': 'etc.death',
   }
 
   class Renderer {


### PR DESCRIPTION
Pull request to add ability to sort by fewest deaths. 
(Useful for blind runs of new content, fun-run contests, and curiosities) 
Used in Shit-Tier Nier (Level 80 Nier Raids; 24-man PVP Alliance Raiding competition; Fewest deaths win prizes, deaths encouraged. Hosted on Crystal DC, First Thursday of every month, 9pm EDT).