### PR TITLE
fix: Hyphenated skill names not being parsed properly

### DIFF
--- a/share/lib/locale.js
+++ b/share/lib/locale.js
@@ -58,7 +58,8 @@
     skillname(n, useAlias) {
       if(!n) return [n, -1]
 
-      let o = n.split('-')
+      const index = n.lastIndexOf('-');
+      const o = index !== -1 ? [n.slice(0, index), n.slice(index + 1)] : [n];
       let dot = this._skill(o[0])
       let name = this.get('skill.' + dot[0]) || dot[0]
       let value = o[1] || -1


### PR DESCRIPTION
The format of the MAXHIT field from ACT ({skillname}-{damage}) caused trouble when the skillname was
hyphenated, as the skillname function used n.split('-') to separated skillname and value.

Fixes #178